### PR TITLE
feat(gcloud): add `gcloud` and `gcloud-login` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tools via **Unix Command Line Interface** with no installation and just using **
     - [Serverless Framework](#serverless-framework)
     - [Terraform](#terraform)
     - [Ookla Speedtest CLI](#ookla-speedtest-cli)
+    - [Google Cloud CLI](#google-cloud-cli)
   - [Author](#author)
   - [Contributors](#contributors)
 
@@ -30,6 +31,7 @@ Tools via **Unix Command Line Interface** with no installation and just using **
 It adds aliases to your `~/.zshrc` file and symbolic links to your `/usr/local/bin/` folder:
 
 ```shell
+# Run this script and choose an option
 ./setup.sh
 ```
 
@@ -228,6 +230,28 @@ speedtest --help
 # run a speed test
 speedtest
 ```
+
+### Google Cloud CLI
+
+```shell
+# If are not logged in, run the command below and follow the steps:
+# 1. Copy/paste the provided URL in your browser
+# 2. Authorize using your Google account
+# 3. Copy/paste the generated auth code back in your terminal
+gcloud-login
+
+# If your current project is [None] or you wanna change it, set one.
+gcloud config set project <PROJECT_ID>
+
+# Test if it is working...
+gcloud version
+gcloud help
+gcloud storage ls
+```
+
+> [gcloud CLI overview](https://cloud.google.com/sdk/gcloud).
+
+> [gcloud auth login](https://cloud.google.com/sdk/gcloud/reference/auth/login).
 
 ## Author
 

--- a/bin/gcloud
+++ b/bin/gcloud
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+IMAGE=eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+WORKDIR=/app
+
+# run from your working directory
+docker run -it --rm \
+    --volume $PWD:$WORKDIR \
+    --volumes-from gcloud-config \
+    --workdir $WORKDIR \
+    --entrypoint gcloud \
+    $IMAGE "${@}"

--- a/bin/gcloud-login
+++ b/bin/gcloud-login
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+IMAGE=eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+WORKDIR=/app
+
+# Remove previous auth configs
+if [[ $(docker ps --all | grep gcloud-config) ]]; then
+    echo "Removing previous $(gcloud-config) container..."
+    docker rm gcloud-config
+fi
+
+# run from your working directory
+docker run -it \
+    --volume $PWD:$WORKDIR \
+    --workdir $WORKDIR \
+    --entrypoint gcloud \
+    --name gcloud-config \
+    $IMAGE auth login

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ Type the number of the OPTION:
 # serverless: Serverless Framework CLI
 # terraform: Terraform CLI
 # speedtest: Ookla Speedtest CLI
+# gcloud: Google Cloud CLI
 # EXIT: To leave this menu
 ==============================================================
 EOF
@@ -98,6 +99,14 @@ install_speedtest() {
     show_msg "Activating speedtest..."
 }
 
+install_gcloud() {
+    sudo ln -sf ${BASEDIR}/bin/gcloud-login /usr/local/bin/gcloud-login
+    show_msg "Activating gcloud-login..."
+
+    sudo ln -sf ${BASEDIR}/bin/gcloud /usr/local/bin/gcloud
+    show_msg "Activating gcloud..."
+}
+
 install_all() {
     install_aws
     install_node
@@ -105,6 +114,7 @@ install_all() {
     install_serverless
     install_terraform
     install_speedtest
+    install_gcloud
 }
 
 # Main
@@ -112,7 +122,7 @@ install_all() {
 show_begin
 
 PS3="Choose an option: "
-select opt in ALL aws node yarn serverless terraform speedtest EXIT; do
+select opt in ALL aws node yarn serverless terraform speedtest gcloud EXIT; do
     case ${opt} in
     ALL) install_all ;;
     aws) install_aws ;;
@@ -121,6 +131,7 @@ select opt in ALL aws node yarn serverless terraform speedtest EXIT; do
     serverless) install_serverless ;;
     terraform) install_terraform ;;
     speedtest) install_speedtest ;;
+    gcloud) install_gcloud ;;
     EXIT) show_msg "Bye o/" ;;
     *) show_help "Error: incorrect option." && exit 2 ;;
     esac


### PR DESCRIPTION
## Context

Closes #18

## Description
<!--
Note: WHAT was done?
- [x] added this
- [x] changed that
- [x] refactor those things
- [ ] and so on...
-->

- [x] add `gcloud-login` command
- [x] add `gcloud` command
- [x] update `setup.sh` script
- [x] update `README`

## Relevant logs
<!--
Note: Inform logs or add screenshots/videos
-->

<img width="524" alt="image" src="https://github.com/My-Tooling/my-ez-cli/assets/13852490/c7b9c0d9-4326-4b9a-9d28-cbff4a961518">


## Steps To Reproduce

1. run `script.sh` to install the new commands.
2. run `gcloud-login` to authorize your CLI make changes on you account.
3. run `gcloud` to have fun.

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

- [README](/tooling-dev/cli#readme)
