### PR TITLE
fix: suppress warning msg mix of host platform

### DIFF
--- a/bin/gcloud
+++ b/bin/gcloud
@@ -6,6 +6,7 @@ WORKDIR=/app
 
 # run from your working directory
 docker run -it --rm \
+    --platform linux/amd64 \
     --volume $PWD:$WORKDIR \
     --volumes-from gcloud-config \
     --workdir $WORKDIR \

--- a/bin/gcloud-login
+++ b/bin/gcloud-login
@@ -12,6 +12,7 @@ fi
 
 # run from your working directory
 docker run -it \
+    --platform linux/amd64 \
     --volume $PWD:$WORKDIR \
     --workdir $WORKDIR \
     --entrypoint gcloud \

--- a/bin/serverless
+++ b/bin/serverless
@@ -11,6 +11,7 @@ fi
 
 # run from your working directory
 docker run -it --rm \
+    --platform linux/amd64 \
     --name serverless-cli \
     --env AWS_PROFILE=$AWS_PROFILE \
     --env AWS_SDK_LOAD_CONFIG=1 \

--- a/bin/speedtest
+++ b/bin/speedtest
@@ -6,4 +6,5 @@ IMAGE=davidcardoso/docker-speedtest:latest
 
 # run from your working directory
 docker run -it --rm \
+    --platform linux/amd64 \
     $IMAGE "${@}"

--- a/bin/terraform
+++ b/bin/terraform
@@ -26,6 +26,7 @@ EOF
 
 # run from your working directory
 docker run -it --rm \
+    --platform linux/amd64 \
     --name terraform-cli \
     --env AWS_PROFILE=${AWS_PROFILE} \
     --volume ${HOME}/.aws:/root/.aws \

--- a/docker/aws-sso-cred/build
+++ b/docker/aws-sso-cred/build
@@ -7,4 +7,6 @@ echo "=========================================================="
 echo "Building '${IMAGE}'..."
 echo "=========================================================="
 
-docker build --tag ${IMAGE} .
+docker build \
+    --platform linux/amd64 \
+    --tag ${IMAGE} .

--- a/docker/serverless/build
+++ b/docker/serverless/build
@@ -7,4 +7,6 @@ echo "=========================================================="
 echo "Building '${IMAGE}'..."
 echo "=========================================================="
 
-docker build --tag ${IMAGE} .
+docker build \
+    --platform linux/amd64 \
+    --tag ${IMAGE} .

--- a/docker/speedtest/build
+++ b/docker/speedtest/build
@@ -9,6 +9,7 @@ echo "Building '${IMAGE}'..."
 echo "=========================================================="
 
 docker build \
+    --platform linux/amd64 \
     --build-arg VERSION=${SPEEDTEST_VERSION} \
     --tag ${IMAGE} \
     .


### PR DESCRIPTION
## Context

Closes #20

## Description

Added the flag `--platform linux/amd64` in some docker run/build commands.

## Relevant logs
...

## Steps To Reproduce

_Before the fix:_
1. run `./bin/gcloud` or `./gcloud-login`
2. note the warning msg in the beginning of the output

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

- [README](/tooling-dev/cli#readme)
