### PR TITLE
fix(#25): error `the input device is not a TTY` from gcloud

### DIFF
--- a/bin/gcloud
+++ b/bin/gcloud
@@ -5,7 +5,7 @@ IMAGE=eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
 WORKDIR=/app
 
 # run from your working directory
-docker run -it --rm \
+docker run --rm \
     --platform linux/amd64 \
     --volume $PWD:$WORKDIR \
     --volumes-from gcloud-config \


### PR DESCRIPTION

## Context
<!--
Note: WHY is it being done?

Example:

Explain here...

Closes #1
-->

It happens when we try to capture the output in a variable using the flag `-it` on the `docker run` command.
An interactive terminal cannot be created in this situaton.

Closes #25

## Description
<!--
Note: WHAT was done?
- [x] added this
- [x] changed that
- [x] refactor those things
- [ ] and so on...
-->

- [x] removed `-it` flag from the `docker run` command of the `bin/gcloud` script.

## Relevant logs
<!--
Note: Inform logs or add screenshots/videos
-->
...

## Steps To Reproduce
<!--
Example: steps to reproduce the behavior:
1. In this environment...
2. With this config...
3. Run '...'
4. See...
-->

See #25.

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

...
